### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ cd wolf-shaper
 Then:
 
 ```
+apt install libxcursor-dev
 BUILD_VST2=true BUILD_LV2=true BUILD_DSSI=true BUILD_JACK=true make
 ```
 


### PR DESCRIPTION
Added information to install `libxcursor-dev` prior to building, as it seems to be a common problem people have.